### PR TITLE
feat: add byte count and token count

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
 			<artifactId>jte-spring-boot-starter-3</artifactId>
 			<version>3.1.12</version>
 		</dependency>
+		<dependency>
+			<groupId>com.knuddels</groupId>
+			<artifactId>jtokkit</artifactId>
+			<version>1.1.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/dev/danvega/cg/ContentGenerationResponse.java
+++ b/src/main/java/dev/danvega/cg/ContentGenerationResponse.java
@@ -1,0 +1,5 @@
+package dev.danvega.cg;
+
+public record ContentGenerationResponse(String content, int tokenCount, String byteCount) {
+
+}

--- a/src/main/java/dev/danvega/cg/util/CountUtils.java
+++ b/src/main/java/dev/danvega/cg/util/CountUtils.java
@@ -1,0 +1,28 @@
+package dev.danvega.cg.util;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.EncodingType;
+
+public class CountUtils {
+
+    public static int countTokens(String text) {
+        EncodingRegistry registry = Encodings.newDefaultEncodingRegistry();
+        Encoding enc = registry.getEncoding(EncodingType.CL100K_BASE);
+        return enc.encode(text).size();
+    }
+
+    public static String humanReadableByteCount(String text) {
+
+        long bytes = text == null ? 0 : text.length();
+        if (bytes < 1024) {
+            return bytes + " B";
+        }
+
+        int exp = (int) (Math.log(bytes) / Math.log(1024));
+        String unit = "KMGTPE".charAt(exp-1) + "B";
+
+        return String.format("%.1f %s", bytes / Math.pow(1024, exp), unit);
+    }
+}

--- a/src/main/jte/result.jte
+++ b/src/main/jte/result.jte
@@ -1,12 +1,22 @@
-@param String content
+@param dev.danvega.cg.ContentGenerationResponse response
 
 <div class="bg-gray-50 rounded-lg border border-gray-200 p-4">
     <div class="relative">
+        <div class="flex gap-4 mb-4">
+            <div class="flex-1 bg-white p-3 rounded-lg border border-gray-200">
+                <div class="text-sm text-gray-600">Bytes</div>
+                <div class="text-lg font-semibold">${response.byteCount()}</div>
+            </div>
+            <div class="flex-1 bg-white p-3 rounded-lg border border-gray-200">
+                <div class="text-sm text-gray-600">Tokens</div>
+                <div class="text-lg font-semibold">${response.tokenCount()}</div>
+            </div>
+        </div>
         <textarea
                 id="result"
                 class="w-full h-96 p-4 font-mono text-sm bg-white rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-none"
                 readonly
-        >${content}</textarea>
+        >${response.content()}</textarea>
 
         <button
                 onclick="copyContent()"

--- a/src/test/java/dev/danvega/cg/util/CountUtilsTest.java
+++ b/src/test/java/dev/danvega/cg/util/CountUtilsTest.java
@@ -1,0 +1,44 @@
+package dev.danvega.cg.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CountUtilsTest {
+
+    @Test
+    public void countTokensNull() {
+        int tokenCount = CountUtils.countTokens(null);
+        assertEquals(0, tokenCount);
+    }
+
+    @Test
+    public void countTokens() {
+        int tokenCount = CountUtils.countTokens("hello world");
+        assertEquals(2, tokenCount);
+    }
+
+    @Test
+    public void countTokensZeroLength() {
+        int tokenCount = CountUtils.countTokens("");
+        assertEquals(0, tokenCount);
+    }
+
+    @Test
+    public void humanReadableByteCount() {
+        String byteCount = CountUtils.humanReadableByteCount("hello world");
+        assertEquals("11 B", byteCount);
+    }
+
+    @Test
+    public void humanReadableByteCountZeroLength() {
+        String byteCount = CountUtils.humanReadableByteCount("");
+        assertEquals("0 B", byteCount);
+    }
+
+    @Test
+    public void humanReadableByteCountNull() {
+        String byteCount = CountUtils.humanReadableByteCount(null);
+        assertEquals("0 B", byteCount);
+    }
+}


### PR DESCRIPTION
Thanks for the repo-content-generator tool. I've added a modest feature which is to display the total number of bytes in human readable form and the token count. 

This closes #3 